### PR TITLE
Fix infinite loop in create_loop

### DIFF
--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -269,13 +269,18 @@ class Hub(object):
         consolidate = self.consolidate
         consolidate_callback = self.consolidate_callback
         on_tick = self.on_tick
-        todo = self._ready
         propagate = self.propagate_errors
 
         while 1:
             for tick_callback in on_tick:
                 tick_callback()
-
+            
+            # To avoid infinite loop where one of the callables adds items to self._ready
+            # (via call_soon or otherwise), we copy the todo list aside and clear the _ready
+            # so items added don't affect this loop and instead they'll be taken care of on the
+            # next itermation of the parent-loop
+            todo = self._ready.copy()
+            self._ready.clear()
             while todo:
                 item = todo.pop()
                 if item:


### PR DESCRIPTION
fixes https://github.com/celery/celery/issues/3712 

Before handling the todo items we "freeze" them by copying them aside and clearing the list.
This way if an item in the todo list appends a new callable to the list itself it will be taken care of in the next iteration of the parent loop instead of producing an infinite loop by adding it to the list we're running on.